### PR TITLE
Simplifies build for firefoxos

### DIFF
--- a/bin/templates/project/cordova/build
+++ b/bin/templates/project/cordova/build
@@ -20,33 +20,14 @@
 */
 
 
-var path = require('path'),
-    build = require('./lib/build'),
-    reqs  = require('./lib/check_reqs'),
+var build = require('./lib/build'),
     args  = process.argv;
 
 // provide help
-if ( args[2] == '--help' || args[2] == '/?' || args[2] == '-h' ||
+if ( args[2] == '--help' || args[2] == '/?' || args[2] == '-h' || args[2] == '/h' ||
                     args[2] == 'help' || args[2] == '-help' || args[2] == '/help') {
     build.help();
     process.exit(0);
-}
-
-// check for the correct argument count, the correct options
-if (  (args.length > 3)
-   || (args[2] && (   (args[2] != '--debug') 
-                   && (args[2] != '--release')))) {
-      console.error('please only use --debug or --release as argument');
-      build.help();
-      process.exit(2);
 } else {
-    var buildOpt     = 'debug';
-    //var buildTypeOpt = 'web';
-    if(args[2] && args[2] == '--release') {
-        buildOpt = 'release'
-    }
-
-    build.buildProject(buildOpt);
+    build.buildProject();
 }
-
-

--- a/bin/templates/project/cordova/lib/build.js
+++ b/bin/templates/project/cordova/lib/build.js
@@ -25,79 +25,15 @@ var path = require('path'),
     shjs = require('shelljs'),
     zip = require('adm-zip'),
     check_reqs = require('./check_reqs'),
-    buildReleaseDirInMerge  = 'build--release',
     platformWwwDir          = path.join('platforms', 'firefoxos', 'www'),
     platformBuildDir        = path.join('platforms', 'firefoxos', 'build'),
-    buildReleaseDirInWwwDir = path.join(platformWwwDir, buildReleaseDirInMerge);
-
-function hasMergesCustomReleaseArtifactsDir() {
-    return fs.existsSync(path.join('merges', 'firefoxos', buildReleaseDirInMerge));
-}
-
-function hasCustomReleaseArtifactsDir() {
-    return fs.existsSync(path.join(platformWwwDir,buildReleaseDirInMerge));
-}
-
-/**
- * hasAllMergesRequiredCustomReleaseArtifacts()
- * checks that merges/firefoxos/build--release is avialable and properly filled.
- *
- */
-function hasAllRequiredCustomReleaseArtifacts() {
-    var mergeDir = path.join('merges', 'firefoxos', buildReleaseDirInMerge);
-    if (!fs.existsSync( path.join(mergeDir, 'manifest.webapp'))) { 
-        console.error('\nPlease provide <project> '+mergeDir+'/manifest.webapp');
-    }
-
-    if (!fs.existsSync( path.join(mergeDir, 'index.html'))) {
-        console.error('\nPlease provide <project> '+mergeDir+'/index.html');
-    }
-
-    return (   fs.existsSync( path.join(mergeDir, 'manifest.webapp'))
-            && fs.existsSync( path.join(mergeDir, 'index.html')) );
-}
-
-/**
- * hasCopiedRequiredCustomReleaseArtifacts()
- * checks that 'cordova prepare' has copied merges/firefoxos to platforms/firefoxos/www
- *
- */
-function hasCopiedAllRequiredCustomReleaseArtifacts() {
-    if (!fs.existsSync( path.join(buildReleaseDirInWwwDir, 'manifest.webapp'))) { 
-        console.error('\n'+path.join(buildReleaseDirInWwwDir, 'manifest.webapp')+' is not found');
-    }
-
-    if (!fs.existsSync( path.join(buildReleaseDirInWwwDir, 'index.html'))) {
-        console.error('\n'+path.join(buildReleaseDirInWwwDir, 'index.html')+' is not found');
-    }
-
-    return (   fs.existsSync( path.join(buildReleaseDirInWwwDir, 'manifest.webapp'))
-            && fs.existsSync( path.join(buildReleaseDirInWwwDir, 'index.html')) );
-}
-
-function moveWwwBuildReleaseToBuild() {
-    hasAllRequiredCustomReleaseArtifacts();
-    
-    shjs.mv('-f', path.join(buildReleaseDirInWwwDir, 'index.html'),       path.join(platformBuildDir, 'index.html'));
-    shjs.mv('-f' ,path.join(buildReleaseDirInWwwDir, 'manifest.webapp'),  path.join(platformBuildDir, 'manifest.webapp'));
-}
-
-// cordova merges merge/firefoxos to platforms/firefoxos/www
-// this removes the 'build--release' directory from platforms/firefoxos/www
-function removeWwwBuildRelease() {
-    if (fs.existsSync(buildReleaseDirInWwwDir)) {
-        shjs.rm('-r', buildReleaseDirInWwwDir);
-    }
-}
+    packageFile             = path.join(platformBuildDir, 'package.zip');
 
 /**
  * buildProject
- *   --debug (default):      
- *
- *   --release
- *
+ *   Creates a zip file int platform/build folder
  */
-exports.buildProject = function(buildTarget){
+exports.buildProject = function(){
 
     // Check that requirements are (stil) met
     if (!check_reqs.run()) {
@@ -106,55 +42,22 @@ exports.buildProject = function(buildTarget){
     }
     
     clean.cleanProject(); // remove old build result
-    
-    // if 'debug' (default), remove files we only need for 'release'
-    if (buildTarget == 'debug') {
-        if(hasCustomReleaseArtifactsDir()){ 
-            removeWwwBuildRelease();
-        }
-        process.exit(0);
+
+    if (!fs.existsSync(platformBuildDir)) {
+        fs.mkdirSync(platformBuildDir);
     }
 
-    if (buildTarget == 'release') {
-        console.log('Building Firefoxos project in '+platformBuildDir);
+    // add the project to a zipfile
+    var zipFile = zip();
+    zipFile.addLocalFolder(platformWwwDir, '.');
+    zipFile.writeZip(packageFile);
 
-        if (!hasAllRequiredCustomReleaseArtifacts()) {
-               console.error('\nCheck \'https://developer.mozilla.org/en-US/Marketplace/Publishing/Packaged_apps\' for the required artifacts');
-               console.error('\n');
-               process.exit(2);
-        }
+    console.log('Firefox OS packaged app built in '+ packageFile);
 
-        if (!hasCopiedAllRequiredCustomReleaseArtifacts()) {
-               console.error('\nIf merges/firefoxos/build-release has proper content, make sure \'cordova prepare firefoxos\' is run.');
-               console.error('\n');
-               process.exit(2);
-        }
-
-        if (!fs.existsSync(platformBuildDir)) {
-            fs.mkdir(platformBuildDir); 
-        }
-
-        moveWwwBuildReleaseToBuild();
-        removeWwwBuildRelease(); 
-
-        // add the project to a zipfile
-        var zipFile = zip();
-        zipFile.addLocalFolder(platformWwwDir, '.');
-        zipFile.writeZip(path.join(platformBuildDir, 'package.zip'));
-
-        process.exit(0);
-    }
-
-    // should never get here
-    console.error('Illegal target to build a firefoxos cordova project ('+buildTarget+')');
-    process.exit(2);
-}
+    process.exit(0);
+};
 
 module.exports.help = function() {
-    console.log('Usage: ' + path.relative(process.cwd(), path.join(__dirname, 'build')) + ' [build_type]');
-    console.log('Build Types : ');
-    console.log('    \'--debug\': Default build.');
-    console.log('    \'--release\': will build a zip-file of the project in \''+platformBuildDir+'\'.');
-    console.log('                  Please provide manifest.webapp and index.html in '+path.join('merges', 'firefoxos', buildReleaseDirInMerge));
-}
-
+    console.log('Usage: cordova build firefoxos');
+    console.log('Build will create the packaged app in \''+platformBuildDir+'\'.');
+};


### PR DESCRIPTION
The build was looking for index.html and manifest.webapp in the merges folder. Removed this requirement. Also no need for debug vs release, now it always builds the packaged app.

Tested in OSX and windows. Needs https://github.com/apache/cordova-firefoxos/pull/6 to work on windows.
