### PR TITLE
cordova.js needs to be copied to platform www

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -26,7 +26,6 @@ var fs = require('fs'),
     ROOT    = path.join(__dirname, '..', '..'),
     check_reqs = require('./check_reqs');
 
-
 exports.createProject = function(project_path,package_name,project_name){
     var VERSION = fs.readFileSync(path.join(ROOT, 'VERSION'), 'utf-8');
     
@@ -61,12 +60,15 @@ exports.createProject = function(project_path,package_name,project_name){
 
     //copy check_reqs file
     shjs.cp( path.join(ROOT, 'bin', 'lib', 'check_reqs.js'), path.join(project_path,'cordova', 'lib'));
-    
+
     //copy cordova directory
     shjs.cp('-r', path.join(ROOT, 'bin', 'templates', 'project', 'cordova'), project_path);
 
     //copy platform_www to project folder
     shjs.cp('-r', path.join(ROOT, 'bin', 'templates', 'project', 'platform_www'), project_path);
+
+    //copy cordova js file
+    shjs.cp('-r', path.join(ROOT, 'cordova-lib', 'cordova.js'), path.join(project_path,'platform_www'));
 
     [
         'run',
@@ -76,4 +78,4 @@ exports.createProject = function(project_path,package_name,project_name){
     ].forEach(function(f) { 
          shjs.chmod(755, path.join(project_path, 'cordova', f));
     });
-}
+};


### PR DESCRIPTION
The [new icon PR](https://github.com/apache/cordova-firefoxos/pull/12) introduced icon files inside the `platform_www` folder. Because `platform_www` folder now exists, `cordova.js` file is not copied over by prepare, [see the code](https://github.com/apache/cordova-lib/blob/master/cordova-lib/src/cordova/prepare.js#L91-L96). We have to manually copy it over.

**Fun Fact**: The [cleanup PR](https://github.com/apache/cordova-firefoxos/pull/11) removed a line that copied the `cordova.js` file to `www` which actually had no effect since the `www` folder was later [wiped out](https://github.com/apache/cordova-lib/blob/master/cordova-lib/src/cordova/metadata/firefoxos_parser.js#L173-L174). This fix just copies the file over to `platform_www` instead of `www`.
