### PR TITLE
Fixing error on new CLI/LIB: cp: no such file or directory

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -42,7 +42,7 @@ exports.createProject = function(project_path,package_name,project_name){
     
     // Check that requirements are met and proper targets are installed
     if (!check_reqs.run()) {
-        console.error('Please make sure you meeet the software requirements in order to build an firefoxos cordova project');
+        console.error('Please make sure you meet the software requirements in order to build an firefoxos cordova project');
         process.exit(2);
     }
     
@@ -68,7 +68,7 @@ exports.createProject = function(project_path,package_name,project_name){
     shjs.cp('-r', path.join(ROOT, 'bin', 'templates', 'project', 'platform_www'), project_path);
 
     //copy cordova js file
-    shjs.cp('-r', path.join(ROOT, 'cordova-lib', 'cordova.js'), path.join(project_path,'platform_www'));
+    shjs.cp('-r', path.join(ROOT, 'cordova-lib', 'cordova.js'), path.join(project_path, 'www'));
 
     [
         'run',


### PR DESCRIPTION
On latest versions of CLI and LIB a `cp: no such file or directory` error was being displayed on the console after adding firefoxos platform.

This was happening because cordova's `platform add` code tries to copy `cordova.js` file from `www` to `platform_www`([code](https://github.com/apache/cordova-lib/commit/3695d6fef8998929189a36681bbe1f99c13f7887)), see [this change](https://github.com/apache/cordova-lib/commit/3695d6fef8998929189a36681bbe1f99c13f7887) for more info. In https://github.com/apache/cordova-firefoxos/commit/72c62a09060a9485d77fc93d84118f1e78706b5a we started moving `cordova.js` into `platform_www` as `prepare` would copy it to `www`.

Fix is to copy `cordova.js` to `www` and let it be copied to `platform_www` by `platform add`.
