### PR TITLE
Discover b2g ports

### DIFF
--- a/bin/lib/b2g.js
+++ b/bin/lib/b2g.js
@@ -19,56 +19,53 @@ specific language governing permissions and limitations
 under the License.
 */
 
-var	exec = require('shelljs').exec,
-    args  = process.argv,
+var exec = require('shelljs').exec,
     os = process.platform,
     B2G_BIN_OSX = 'b2g/B2G.app/Contents/MacOS/b2g-bin',
-	FX_PROFILES_OSX = 'Library/Application Support/Firefox/Profiles/',
-	B2G_BIN_LINUX = 'b2g/b2g-bin',
-	FX_PROFILES_LINUX = '.mozilla/firefox/',
-	NETSTAT_CMD = 'netstat -lnptu',
-	LSOF_CMD = 'lsof -i -n -P -sTCP:LISTEN';
+    FX_PROFILES_OSX = 'Library/Application Support/Firefox/Profiles',
+    B2G_BIN_LINUX = 'b2g/b2g-bin',
+    FX_PROFILES_LINUX = '.mozilla/firefox',
+    NETSTAT_CMD = 'netstat -lnptu',
+    LSOF_CMD = 'lsof -i -n -P -sTCP:LISTEN';
 
 exports.discoverPorts = function (callback) {
-	
-	var ports = [];
+    
+    var ports = [];
+
+    if (os == 'darwin') {
+        var output = exec(LSOF_CMD, {silent: true}).output;
+        var regex = /^b2g[-bin]?.*[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:([0-9]*)/;
+        var lines = output.split('\n');
+        lines.forEach(function(line) {
+            var matches = regex.exec(line);
+            if (matches && +matches[1] != 2828)
+                ports.push(+matches[1])
+        })
  
-	if (os == 'darwin') {
-		var output = exec(LSOF_CMD, {silent: true}).output;
-		var regex = /^b2g[-bin]?.*[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:([0-9]*)/;
-		var lines = output.split('\n');
-		for (var line=0; line < lines.length; line++) {
-			var matches = regex.exec(lines[line]);
-			
-			if (matches && +matches[1] != 2828)
-				ports.push(+matches[1])
-		}
+    } else
+    if (os == 'linux') {
+        var output = exec(NETSTAT_CMD, {silent: true}).output;
+        var regex = /tcp.*[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:([0-9]+).*LISTEN.*\/b2g[-bin]?/
+        var lines = output.split('\n');
+        lines.forEach(function(line) {
+            var matches = regex.exec(line);
+            if (matches && +matches[1] != 2828)
+                ports.push(+matches[1])
+        })
  
-	} else
-	if (os == 'linux') {
-		var output = exec(NETSTAT_CMD, {silent: true}).output;
-		var regex = /tcp.*[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:([0-9]+).*LISTEN.*\/b2g[-bin]?/
-		var lines = output.split('\n');
-		for (var line=0; line < lines.length; line++) {
-			var matches = regex.exec(lines[line]);
-			
-			if (matches && +matches[1] != 2828)
-				ports.push(+matches[1])
-		}
+    } else {
+        return callback(new Error("OS not supported for running"))
+    }
  
-	} else {
-		return callback(new Error("OS not supported for running"))
-	}
- 
-	callback(null, ports)
+    callback(null, ports)
  
 }
 
 if (require.main === module) {
     (function() {
         exports.discoverPorts(function(err, ports){
-        	if (err) return console.log(err)
-        	console.log("Running FirefoxOS simulators (B2G) on ports", ports)
+            if (err) return console.log(err)
+            console.log("Running FirefoxOS simulators (B2G) on ports", ports)
         });
     })();
 }


### PR DESCRIPTION
This should be an helper library that should contain functions to find the port of an existing b2g simulator (Firefox OS simulator) and eventually functions to start a new simulator listening on a specific port, so that `cordova run` and `cordova emulate` can finally work.

The idea is about running `cordova emulate`
- you first scan listening ports to find existing b2g, connect in case they are found, or a specific port or version is specified (implemented for OS X and Linux)
- if no ports is found you then start a new simulator (coming soon)

The way I scan ports is straight forward, lsof or netstat in localhost and I find b2g processes.
