### PR TITLE
[fxos] Remove hardcoded cordova version

### DIFF
--- a/cordova-lib/cordova.js
+++ b/cordova-lib/cordova.js
@@ -1208,7 +1208,6 @@ define("cordova/platform", function(require, exports, module) {
 
 module.exports = {
     id: 'firefoxos',
-    cordovaVersion: '3.0.0',
 
     bootstrap: function() {
         require('cordova/modulemapper').clobbers('cordova/exec/proxy', 'cordova.commandProxy');


### PR DESCRIPTION
There doesn't seem to be a need to hardcode cordova version. It causes plugins that require a higher versions to fail to install for firefoxos.  
